### PR TITLE
release build testing

### DIFF
--- a/.github/workflows/Releaser.yml
+++ b/.github/workflows/Releaser.yml
@@ -4,6 +4,9 @@
 name: Release Build
 
 on:
+  push:
+    branches:
+      - integrator-testing
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
for some #### reason i cant activate the workflow trigger despite having `workflow_dispatch` trigger on, so here is an attempted workaround to do that